### PR TITLE
Make api host configurable

### DIFF
--- a/lib/circleci/config.rb
+++ b/lib/circleci/config.rb
@@ -8,10 +8,9 @@ module CircleCi
 
     VERSION = 'v1'
     DEFAULT_HOST = "https://circleci.com/api/#{VERSION}"
-    DEFAULT_PORT = 80 # @private
+    DEFAULT_PORT = 80
 
-    attr_accessor :token
-    attr_reader   :host, :port # @private
+    attr_accessor :token, :host, :port
 
     ##
     #


### PR DESCRIPTION
It's sometimes useful to be able to use some API endpoint other than the default. For instance someone (like me) might want to use a different endpoint to tunnel the requests via transparent proxy.

@mtchavez please review
