### PR TITLE
Loosen dependency on rest-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
   remote: .
   specs:
     circleci (0.0.9)
-      rest-client (~> 1.7.2, >= 1.7.2)
+      rest-client (~> 1.6)
 
 GEM
   remote: https://rubygems.org/

--- a/circleci.gemspec
+++ b/circleci.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.md']
 
   # Gem Dependencies
-  s.add_dependency 'rest-client', '~> 1.7.2', '>= 1.7.2'
+  s.add_dependency 'rest-client', '~> 1.6'
 
   # Dev Dependencies
   s.add_development_dependency 'coveralls', '~> 0.7.1',  '>= 0.7.1'


### PR DESCRIPTION
My project has the `heroku` gem installed, which forces rest-client to 1.6. So I can't install the latest version of `circleci`, which locks rest-client at 1.7. `circleci` actually works fine with either version of rest-client. This change allows rest-client 1.6 to be used.
