### PR TITLE
Added optional proxy configuration option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     hashdiff (0.2.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    json (1.8.1)
+    json (1.8.3)
     method_source (0.8.2)
     mime-types (2.4.3)
     multi_json (1.11.2)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,16 @@ gem 'circleci'
 
 ### Configuring
 
-Configure using an API token from Circle
+Configure using an API token from CircleCI
 
 ```ruby
 CircleCi.configure do |config|
+  # CircleCI token
   config.token = 'my-token'
+  
+  # Optionally supply a proxy url to have all requests 
+  # to CircleCI routed through the proxy. 
+  config.proxy = 'http://myproxy.com'
 end
 ```
 

--- a/lib/circleci/config.rb
+++ b/lib/circleci/config.rb
@@ -9,8 +9,9 @@ module CircleCi
     VERSION = 'v1'
     DEFAULT_HOST = "https://circleci.com/api/#{VERSION}"
     DEFAULT_PORT = 80
+    DEFAULT_PROXY = nil
 
-    attr_accessor :token, :host, :port
+    attr_accessor :token, :host, :port, :proxy
 
     ##
     #
@@ -19,6 +20,7 @@ module CircleCi
     def initialize
       @host = DEFAULT_HOST
       @port = DEFAULT_PORT
+      @proxy = DEFAULT_PROXY
     end
 
   end

--- a/lib/circleci/http.rb
+++ b/lib/circleci/http.rb
@@ -8,6 +8,7 @@ module CircleCi
 
     def initialize(_config)
       @config, @errors, @success, @over_limit, @suspended = _config, [], false, false, false
+      RestClient.proxy = @config.proxy
     end
 
     def get(path, params = {})

--- a/spec/circleci_spec.rb
+++ b/spec/circleci_spec.rb
@@ -9,15 +9,25 @@ describe CircleCi do
         config.token = 'test-key'
       end
       CircleCi.config.token.should eql 'test-key'
+      CircleCi.config.proxy.should be_nil
     end
 
-    it 'can be accessed after being set' do
+    it 'can access the API token after being set' do
       CircleCi.configure do |config|
         config.token = 'test-key'
       end
       CircleCi.config.token.should eql 'test-key'
       CircleCi.config.token = 'new-key'
       CircleCi.config.token.should eql 'new-key'
+    end
+
+    it 'can access the proxy after being set' do
+      CircleCi.configure do |config|
+        config.proxy = 'http://username:password@myproxy.com:1234'
+      end
+      CircleCi.config.proxy.should eql 'http://username:password@myproxy.com:1234'
+      CircleCi.config.proxy = 'http://myproxy.com'
+      CircleCi.config.proxy.should eql 'http://myproxy.com'
     end
 
   end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CircleCi::Http do
+
+  context 'initialize' do
+
+    it 'sets the proxy server' do
+      config = double('Config', proxy: 'http://myproxy.com')
+      RestClient.should_receive(:proxy=).with(config.proxy).once
+      CircleCi::Http.new(config)
+    end
+
+  end
+
+end


### PR DESCRIPTION
We've recently started using this gem within our organisation. However due to the security in which the application is to be deployed to, we have to route all external requests through a proxy.

This pull request adds the additional proxy option to the RestClient calls, via a configuration option set in the CircleCI configure block.