### PR TITLE
Add enpoints for envvars

### DIFF
--- a/lib/circleci/project.rb
+++ b/lib/circleci/project.rb
@@ -99,6 +99,32 @@ module CircleCi
 
     ##
     #
+    # Get the project envvars
+    #
+    # @param username [String] - User or org name who owns project
+    # @param project  [String] - Name of project
+    # @return         [CircleCi::Response] - Response object
+
+    def self.envvars username, project
+      CircleCi.http.get "/project/#{username}/#{project}/envvar"
+    end
+
+    ##
+    #
+    # Sets an envvar for a project
+    #
+    # @param username [String] - User or org name who owns project
+    # @param project  [String] - Name of project
+    # @param envvar   [Hash] - {name: 'foo', value: 'bar'}
+    # @return         [CircleCi::Response] - Response object
+
+    def self.set_envvar username, project, envvar
+      body = envvar
+      CircleCi.http.post "/project/#{username}/#{project}/envvar", {}, body
+    end
+
+    ##
+    #
     # Follow the project
     #
     # @param username [String] - User or org name who owns project

--- a/spec/cassettes/project/envvar/success.yml
+++ b/spec/cassettes/project/envvar/success.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://circleci.com/api/v1/project/mtchavez/circleci/envvar?circle-token=d121d128bf0b9d185cbad163fa410d958a30d37d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Feb 2016 20:41:32 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - ab_test_user_seed=0.9096470094715854;Expires=Thu, 16 Feb 2017 20:41:32 +0000;Path=/;Secure
+      - ring-session=q%2FPBg2ilGwNe%2Ffg5NDgOiayIdRjuBwPWg6UMn41tt2b4zUENr0dPRX5QHFkkgNxfJ51p0h3eX2mGUvasu8WP%2BbLPAj28qYbjvOZlBIXGdXSVzA2BKdLiJnhUuBlFDm2awwqI5Ise%2B%2BoZkaGpYKa6r7dUZ7VzetovL6HTDbOdObNWTrAjttIGZBnS6pDEZSEvhgmCyXYjDxyU%2Blxh%2FBLeEIV1bd1fm1vae3vzzbq78G4%3D--Omv0GhRbvbemu7sElHsScgxvZHYOcIISfTkUoHpmA7Y%3D;Path=/;HttpOnly;Expires=Sat,
+        11 Feb 2017 20:00:28 +0000;Max-Age=31536000;Secure
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Circleci-Identity:
+      - i-f046dd68
+      X-Circleci-Request-Id:
+      - 4921837e-b476-43b3-b14f-2091321f6c33
+      X-Circleci-Scopes:
+      - ":all"
+      - ":none"
+      - ":read-settings"
+      - ":status"
+      - ":view-builds"
+      - ":write-settings"
+      X-Frame-Options:
+      - DENY
+      X-Route:
+      - "/api/v1/project/:username/:repo/envvar"
+      Content-Length:
+      - '52'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"name":"COVERALLS_REPO_TOKEN","value":"xxxxskJS"}]'
+    http_version: 
+  recorded_at: Tue, 16 Feb 2016 20:41:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/project/envvar/unsuccessfully.yml
+++ b/spec/cassettes/project/envvar/unsuccessfully.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://circleci.com/api/v1/project/mtchavez/asdf-bogus/envvar?circle-token=d121d128bf0b9d185cbad163fa410d958a30d37d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Feb 2016 20:41:27 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - ab_test_user_seed=0.6938901636496478;Expires=Thu, 16 Feb 2017 20:41:27 +0000;Path=/;Secure
+      - ring-session=HxcBlqCMBAPgqwCQqX51Z3B4Guh7835FfCmj1KScp8Tzzcm0mX9yTeTD8JGQEyjewgGDTVXdJfuL3EP45yMqquQY5T7dWNSBG3GdudoMjRx45CnilL8%2B9uTcdpJp4ZGXNRt%2B3uuee5peou1%2FzkQvHYryWSXCnnqwKxKCwGCRWd2DoRIr5%2BNn%2BEgtfgVIhBelYfTc3Z4OYstNXAEtM6jj5qtPTdOORblyDTktOx744Io%3D--mmvZjCyYVHfIAOc2QBYy7sHJP4rrj5k%2Betw48JGy0WQ%3D;Path=/;HttpOnly;Expires=Sat,
+        11 Feb 2017 19:57:26 +0000;Max-Age=31536000;Secure
+      X-Circleci-Identity:
+      - i-d06a3929
+      X-Circleci-Request-Id:
+      - 90e4d054-2699-42ca-be1c-0df0825bf45a
+      X-Frame-Options:
+      - DENY
+      X-Route:
+      - "/api/v1/project/:username/:repo/envvar"
+      Content-Length:
+      - '31'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Project not found"}'
+    http_version: 
+  recorded_at: Tue, 16 Feb 2016 20:41:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/project/set_envvar/success.yml
+++ b/spec/cassettes/project/set_envvar/success.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://circleci.com/api/v1/project/mtchavez/circleci/envvar?circle-token=d121d128bf0b9d185cbad163fa410d958a30d37d
+    body:
+      encoding: US-ASCII
+      string: name=TESTENV&value=testvalue
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Feb 2016 20:41:33 GMT
+      Location:
+      - https://circleci.com/api/v1/project/mtchavez/circleci/envvar/TESTENV
+      Server:
+      - nginx
+      Set-Cookie:
+      - ab_test_user_seed=0.656811090700415;Expires=Thu, 16 Feb 2017 20:41:33 +0000;Path=/;Secure
+      - ring-session=kgZ2c%2BN%2Bxbk7eruuMsKEIravl%2BsOlSvPto1lyE6uuyh1vA%2FsPWszWTnak09WHxmDFaDgqdde0o5qL7YStUhwbSS9%2FNAhiJAmWYvRU2y%2BHxpxQneHQNz2ekI7VhzggQIWCxwS03BHqHTolCZY6Ef%2BWfAbBIjJOIGnjlWTi1KXqWnHr9unGg%2BcKmC9mBcz2etO9HxDm%2FfIYTqtWqyJKn%2FGEYRfm18x6HxbpQ4OkpBPFSM%3D--SM96RxlLf18L8fESXiK1WiyPrN8%2BlCRJdt036Wu6BqY%3D;Path=/;HttpOnly;Expires=Sat,
+        11 Feb 2017 20:01:21 +0000;Max-Age=31536000;Secure
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Circleci-Identity:
+      - i-ed51286d
+      X-Circleci-Request-Id:
+      - d4d78ce3-d146-4f31-a384-8531ccc1fcd4
+      X-Circleci-Scopes:
+      - ":all"
+      - ":none"
+      - ":read-settings"
+      - ":status"
+      - ":view-builds"
+      - ":write-settings"
+      X-Frame-Options:
+      - DENY
+      X-Route:
+      - "/api/v1/project/:username/:repo/envvar"
+      Content-Length:
+      - '37'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"name":"TESTENV","value":"xxxxalue"}'
+    http_version: 
+  recorded_at: Tue, 16 Feb 2016 20:41:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/project/set_envvar/unsuccessfully.yml
+++ b/spec/cassettes/project/set_envvar/unsuccessfully.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://circleci.com/api/v1/project/mtchavez/asdf-bogus/envvar?circle-token=d121d128bf0b9d185cbad163fa410d958a30d37d
+    body:
+      encoding: US-ASCII
+      string: name=TESTENV&value=testvalue
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Feb 2016 20:41:15 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - ab_test_user_seed=0.5679000950422193;Expires=Thu, 16 Feb 2017 20:41:15 +0000;Path=/;Secure
+      - ring-session=FGyOze029ZVuOy8WGvs4JBpIjqE6lVeLaZ74y6WIBsFGQ1gyILGlpVF2MhlYEORHu%2BcXMv%2BegGBV8y2hvoNggl3wcQHqnD4yx4g9s%2BhkK%2BlKX8TQyPxYz%2F0J1%2F0MTWLzjQFX26hOGUAancR3dIymJrPl6%2BmK3swKKa6g%2BetdhRKM6sp3ihaWD1wE086elT39WM5tx%2Fdj3wzESshs3I3GfCpxW0SA84oMLPSrUOO3Jo0%3D--JLTGrGFCKFDgpm3pvPvpzaXO7Q%2FZ5H%2FkLBjQKxljY2g%3D;Path=/;HttpOnly;Expires=Sat,
+        11 Feb 2017 19:58:15 +0000;Max-Age=31536000;Secure
+      X-Circleci-Identity:
+      - i-1443d88c
+      X-Circleci-Request-Id:
+      - 3bc8f1f1-5cc7-43d3-ab65-cd9cbf60913f
+      X-Frame-Options:
+      - DENY
+      X-Route:
+      - "/api/v1/project/:username/:repo/envvar"
+      Content-Length:
+      - '31'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Project not found"}'
+    http_version: 
+  recorded_at: Tue, 16 Feb 2016 20:41:23 GMT
+recorded_with: VCR 2.9.3

--- a/spec/circleci/project_spec.rb
+++ b/spec/circleci/project_spec.rb
@@ -459,4 +459,81 @@ describe CircleCi::Project do
 
   end
 
+  describe 'envvars' do
+
+    context 'successfully', vcr: { cassette_name: 'project/envvar/success', record: :none } do
+
+      let(:res) { CircleCi::Project.envvars 'mtchavez', 'circleci' }
+
+      it 'returns a response object' do
+        res.should be_an_instance_of(CircleCi::Response)
+        res.should be_success
+      end
+
+      it 'returns a response hash' do
+        res.body.should be_an_instance_of(Array)
+        envvar = res.body.first
+        envvar.should have_key 'name'
+        envvar.should have_key 'value'
+      end
+
+    end
+
+    context 'unsuccessfully', vcr: { cassette_name: 'project/envvar/unsuccessfully', record: :none } do
+
+      let(:res) { CircleCi::Project.envvars 'mtchavez', 'asdf-bogus' }
+      let(:message) { 'Project not found' }
+
+      it 'returns a response object' do
+        res.should be_an_instance_of(CircleCi::Response)
+        res.should_not be_success
+      end
+
+      it 'returns an error message' do
+        res.body.should be_an_instance_of(Hash)
+        res.body['message'].should eql message
+      end
+
+    end
+
+  end
+
+  describe 'set_envvar' do
+
+    context 'successfully', vcr: { cassette_name: 'project/set_envvar/success', record: :none } do
+
+      let(:res) { CircleCi::Project.set_envvar 'mtchavez', 'circleci', { name: 'TESTENV', value: 'testvalue' } }
+
+      it 'returns a response object' do
+        res.should be_an_instance_of(CircleCi::Response)
+        res.should be_success
+      end
+
+      it 'returns a response hash' do
+        res.body['name'].should eq 'TESTENV'
+        # obfuscated value
+        res.body['value'].should eq 'xxxxalue'
+      end
+
+    end
+
+    context 'unsuccessfully', vcr: { cassette_name: 'project/set_envvar/unsuccessfully', record: :none } do
+
+      let(:res) { CircleCi::Project.set_envvar 'mtchavez', 'asdf-bogus', { name: 'TESTENV', value: 'testvalue' } }
+      let(:message) { 'Project not found' }
+
+      it 'returns a response object' do
+        res.should be_an_instance_of(CircleCi::Response)
+        res.should_not be_success
+      end
+
+      it 'returns an error message' do
+        res.body.should be_an_instance_of(Hash)
+        res.body['message'].should eql message
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Hi,

  I've added support for using CircleCI's API endpoints for project level envvars. I ran my tests without VCR using my own Circle Token and verified that they work. It's not clear to me how you generate VCR cassettes with your test account token in the project. I get a project not found error when trying to interact with `Shopify/google_oauth`, as the existing tests do. Perhaps the token included in `.env` is out of date or that project has been removed?