### PR TITLE
Use HTTParty as HTTP backend

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    circleci (0.2.2)
-      rest-client (~> 1.8)
+    circleci (0.2.3)
+      httparty (~> 0.13)
 
 GEM
   remote: https://rubygems.org/
@@ -21,21 +21,19 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.23)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.0)
     ethon (0.8.1)
       ffi (>= 1.3.0)
     ffi (1.9.10)
     gemcutter (0.7.1)
     hashdiff (0.3.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     json (1.8.3)
     method_source (0.8.2)
-    mime-types (2.4.3)
     multi_json (1.11.2)
-    netrc (0.10.3)
+    multi_xml (0.5.5)
     parser (2.3.0.6)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -46,10 +44,6 @@ GEM
     rainbow (2.1.0)
     rake (10.5.0)
     redcarpet (3.3.4)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -81,9 +75,6 @@ GEM
     tins (1.6.0)
     typhoeus (1.0.1)
       ethon (>= 0.8.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.6)
     unicode-display_width (0.3.1)
     vcr (3.0.1)
     webmock (1.24.0)
@@ -101,7 +92,7 @@ DEPENDENCIES
   dotenv (~> 2.1.0, >= 2.1.0)
   gemcutter (~> 0.7.1, >= 0.7.1)
   multi_json (~> 1.11.2, >= 1.11.2)
-  pry (~> 0.10.3, >= 0.10.3)
+  pry
   rake (~> 10.5.0, >= 10.5.0)
   redcarpet (~> 3.3.4, >= 3.3.4)
   rspec (~> 2.14.1, >= 2.14.1)

--- a/circleci.gemspec
+++ b/circleci.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md]
 
   # Gem Dependencies
-  s.add_dependency 'rest-client', '~> 1.8'
+  s.add_dependency 'httparty', '~> 0.13'
 
   # Dev Dependencies
   s.add_development_dependency 'coveralls',     '~> 0.8.11', '>= 0.8.11'

--- a/lib/circleci.rb
+++ b/lib/circleci.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'rest-client'
+require 'httparty'
 require 'net/http'
 
 files = %w[

--- a/lib/circleci/http.rb
+++ b/lib/circleci/http.rb
@@ -16,15 +16,19 @@ module CircleCi
     end
 
     def get(path, params = {})
-      request 'get', "#{path}?#{RestClient::Payload.generate(build_params(params))}"
+      request 'get', "#{path}?#{payload_generate(build_params(params))}"
+    end
+
+    def payload_generate(params)
+      URI.encode_www_form(params)
     end
 
     def post(path, params = {}, body = {})
-      request 'post', "#{path}?#{RestClient::Payload.generate(build_params(params))}", body
+      request 'post', "#{path}?#{payload_generate(build_params(params))}", body
     end
 
     def delete(path, params = {})
-      request 'delete', "#{path}?#{RestClient::Payload.generate(build_params(params))}"
+      request 'delete', "#{path}?#{payload_generate(build_params(params))}"
     end
 
     def headers
@@ -35,53 +39,45 @@ module CircleCi
       params.merge('circle-token' => @config.token)
     end
 
-    def create_request_args(http_verb, url, body)
+    def create_request_args(http_verb, body)
       args = {
-        method: http_verb.to_sym,
-        url: url,
         headers: headers }
-      args[:payload] = body if http_verb == 'post'
+      args[:payload] = body if http_verb.to_sym == :post
       args.merge!(@config.request_overrides)
       args
     end
 
     def request(http_verb, path, body = {})
       url  = "#{@config.uri}#{path}"
-      args = create_request_args http_verb, url, body
+      args = create_request_args http_verb, body
+      response = HTTParty.public_send(http_verb, url, args)
+      handle_response(response, path)
+      Response.new(self, response.code, path)
+    end
 
-      RestClient::Request.execute(args) do |res, _, raw_res|
-        body = res.body.to_s
-        body.force_encoding(Encoding::UTF_8)
-        code = raw_res.code.to_i
+    def handle_response(http_response, path)
+      self.errors   = []
 
-        self.response = body
-        self.errors   = []
-
-        handle_response(body, code, path)
-        Response.new(self, code, path)
+      parsed = http_response.parsed_response
+      unless parsed.respond_to?(:to_h)
+        begin
+          parsed = JSON.parse(parsed)
+        rescue JSON::ParserError
+        end
       end
-    end
 
-    def parsed_body(body)
-      JSON.parse(body)
-    rescue
-      nil
-    end
-
-    def handle_response(body, code, path)
-      parsed = parsed_body(body)
-      successful_code = (200..299).cover?(code)
+      successful_code = (200..299).cover?(http_response.code)
       self.response = parsed if parsed
       self.success = true
 
       # Some responses are empty but are successful
-      if body == '""' && successful_code
+      if http_response.body == '""' && successful_code
         self.response = ''
       elsif parsed && successful_code
         # Response is successful
       else
         self.success = false
-        self.errors = [RequestError.new(body, code, path)]
+        self.errors = [RequestError.new(http_response.body, http_response.code, path)]
       end
     end
   end


### PR DESCRIPTION
`RestClient` has heavy dependencies which lead to extra 10+ MB on require runtime:

```
$ derailed bundle:mem
    TOP: 50.4531 MiB <-- total memory consumed by my app
      circleci: 16.793 MiB <-- 32% of that is consumed by circleci
    dependencies
        rest-client: 16.4531 MiB
          /Users/kir/Projects/spy/vendor/bundle/gems/rest-client-1.8.0/lib/restclient: 16.4531 MiB
            /Users/kir/Projects/spy/vendor/bundle/gems/rest-client-1.8.0/lib/restclient/request: 10.9609 MiB
              mime/types: 10.8008 MiB (Also required by: /Users/kir/Projects/spy/vendor/bundle/gems/rest-client-1.8.0/lib/restclient/payload, mime/types/columnar)
            /Users/kir/Projects/spy/vendor/bundle/gems/rest-client-1.8.0/lib/restclient/abstract_response: 4.9961 MiB
              http-cookie: 4.9727 MiB
                http/cookie: 4.9102 MiB
                  domain_name: 4.7305 MiB
                    domain_name/etld_data: 4.2695 MiB
```
