### PR TITLE
Adds support for passing a revision and/or parallel containers to a build

### DIFF
--- a/lib/circleci/project.rb
+++ b/lib/circleci/project.rb
@@ -33,11 +33,15 @@ module CircleCi
     # @param project  [String] - Name of project
     # @param branch   [String] - Name of branch
     # @param build_parameters   [Hash] - Optional Build Parameters
+    # @param revision   [String] - Optional Revision SHA
+    # @param parallel   [Int] - Optional Number of containers to use for the build
     # @return         [CircleCi::Response] - Response object
 
-    def self.build_branch(username, project, branch, build_parameters = {})
+    def self.build_branch(username, project, branch, build_parameters = {}, revision = nil, parallel = nil)
       body = {}
       body['build_parameters'] = build_parameters unless build_parameters.empty?
+      body['revision'] = revision unless revision.nil?
+      body['parallel'] = parallel unless parallel.nil?
       CircleCi.http.post "/project/#{username}/#{project}/tree/#{branch}", {}, body
     end
 

--- a/spec/circleci/project_spec.rb
+++ b/spec/circleci/project_spec.rb
@@ -72,6 +72,18 @@ describe CircleCi::Project do
 
         res.should be_success
       end
+
+      it 'can pass a specific revision' do
+        res = CircleCi::Project.build_branch 'ad2games', 'soapy_cake', 'master', {}, '123456'
+
+        res.should be_success
+      end
+
+      it 'can use parallel containers' do
+        res = CircleCi::Project.build_branch 'ad2games', 'soapy_cake', 'master', {}, nil, 2
+
+        res.should be_success
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Tests added
- [x] All tests pass
- [x] Branch is up to date and mergeable

## Changes

Allow users to pass the `revision` and `parallel` params to circle builds

## Verify

- Run a build against a specific SHA that is not the HEAD for a repo
- Run a build with a specific number of parallel containers