### PR TITLE
Project#envvar method naming fix

### DIFF
--- a/lib/circleci/project.rb
+++ b/lib/circleci/project.rb
@@ -102,8 +102,17 @@ module CircleCi
     # @param project  [String] - Name of project
     # @return         [CircleCi::Response] - Response object
 
-    def self.envvars(username, project)
+    def self.envvar(username, project)
       CircleCi.http.get "/project/#{username}/#{project}/envvar"
+    end
+
+    ##
+    #
+    # @deprecated Please use [CircleCi::Project#envvar]
+    def self.envvars(username, project)
+      logger = Logger.new(STDOUT)
+      logger.warn('[Deprecated] Project#envvars is deprecated please use Project#envvar')
+      envvar username, project
     end
 
     ##

--- a/spec/circleci/project_spec.rb
+++ b/spec/circleci/project_spec.rb
@@ -402,9 +402,9 @@ describe CircleCi::Project do
     end
   end
 
-  describe 'envvars' do
+  describe 'envvar' do
     context 'successfully', vcr: { cassette_name: 'project/envvar/success', record: :none } do
-      let(:res) { CircleCi::Project.envvars 'mtchavez', 'circleci' }
+      let(:res) { CircleCi::Project.envvar 'mtchavez', 'circleci' }
 
       it 'returns a response object' do
         res.should be_an_instance_of(CircleCi::Response)
@@ -420,7 +420,7 @@ describe CircleCi::Project do
     end
 
     context 'unsuccessfully', vcr: { cassette_name: 'project/envvar/unsuccessfully', record: :none } do
-      let(:res) { CircleCi::Project.envvars 'mtchavez', 'asdf-bogus' }
+      let(:res) { CircleCi::Project.envvar 'mtchavez', 'asdf-bogus' }
       let(:message) { 'Project not found' }
 
       it 'returns a response object' do
@@ -432,6 +432,10 @@ describe CircleCi::Project do
         res.body.should be_an_instance_of(Hash)
         res.body['message'].should eql message
       end
+    end
+
+    context 'envvars deprecation' do
+      # TODO: Fill this in
     end
   end
 


### PR DESCRIPTION
- [x] Tests added
- [x] All tests pass
- [x] Branch is up to date and mergeable
- [x] README and documentation updated

## Changes

* Fix from plural envvar to envvars for consistency with API endpoint
* Preserve old functionality

## Verify

Example in `README` for envvar call should work now.

---

fixes #70