### PR TITLE
Use POST for project enable

### DIFF
--- a/lib/circleci/project.rb
+++ b/lib/circleci/project.rb
@@ -84,7 +84,7 @@ module CircleCi
     # @param project  [String] - Name of project
     # @return         [CircleCi::Response] - Response object
     def self.enable(username, project)
-      CircleCi.request("/project/#{username}/#{project}/enable").delete
+      CircleCi.request("/project/#{username}/#{project}/enable").post
     end
 
     ##


### PR DESCRIPTION
In #75, you switched a `POST` into a `DELETE`, I'm not sure it's causing issues on CircleCI, but it's breaking my test suite using VCR which expects a POST.

- [ ] Tests added
- [ ] All tests pass
- [ ] Branch is up to date and mergeable
- [ ] README and documentation updated

## Changes

Change project enable to use POST rather than DELETE.

## Verify

I wasn't able to record the new cassettes with the included token. I only get 401s.
