### PR TITLE
net/http does not bring in OpenSSL. It must be explicitly required

### DIFF
--- a/lib/circleci/request.rb
+++ b/lib/circleci/request.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 # frozen_string_literal: true
 module CircleCi
   ##


### PR DESCRIPTION
- ~~[ ] Tests added~~
- [x] All tests pass
- [x] Branch is up to date and mergeable
- ~~[ ] README and documentation updated~~

## Changes

#75 replaced RestClient with `net/http`, which doesn't bring in openssl. So, uses of https://github.com/circle-cli/circle-cli, have been encountering the following issue in https://github.com/circle-cli/circle-cli/issues/21:

```
/Users/duncan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/circleci-1.0.1/lib/circleci/request.rb:11:in `<class:Request>': uninitialized constant CircleCi::Request::OpenSSL (NameError)
Did you mean?  OpenStruct
```

## Verify

To reproduce, run the following command within the repo:

```
$ bundle exec irb -r circleci
```

## Notes

I couldn't add tests for this, because I think VCR brings in OpenSSL.