### PR TITLE
Require forwardable

### DIFF
--- a/lib/circleci/response.rb
+++ b/lib/circleci/response.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 # frozen_string_literal: true
 module CircleCi
   ##


### PR DESCRIPTION
See: https://github.com/circle-cli/circle-cli/issues/21

```
uninitialized constant CircleCi::Response::Forwardable (NameError)
```

