### PR TITLE
Fix method name for envvar_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ Creates a new environment variable for a project
 
 ```ruby
 environment = { name: 'foo', value: 'bar' }
-res = CircleCi::Project.envvar 'username', 'repo', environment
+res = CircleCi::Project.set_envvar 'username', 'repo', environment
 res.success?
 ```
 


### PR DESCRIPTION
The readme has the method name `envvar` in the section heading, but the example uses the wrong method name. Looks like it was copy pasta'd.