### PR TITLE
Add params to recent builds branch for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,12 @@ Build summary for each of the last 30 recent builds for a specific branch, order
 project = CircleCi::Project.new 'username', 'reponame'
 res = project.recent_builds_branch 'branch'
 
+# Use params to filter by status
+res = project.recent_builds_branch 'branch', filter: 'failed'
+
+# Use params to limit and give an offset
+res = project.recent_builds_branch 'branch', limit: 10, offset: 50
+
 # Use a different config with another user token
 project = CircleCi::Project.new 'username', 'reponame', other_project_config
 project.recent_builds_branch 'branch'

--- a/lib/circleci/project.rb
+++ b/lib/circleci/project.rb
@@ -142,10 +142,11 @@ module CircleCi
     #
     # Get all recent builds for a specific branch of a project
     #
-    # @param branch [String] - Name of branch
-    # @return       [CircleCi::Response] - Response object
-    def recent_builds_branch(branch)
-      CircleCi.request(conf, "#{base_path}/tree/#{branch}").get
+    # @param branch   [String] - Name of branch
+    # @param params   [Hash] - Parameters for builds (limit, offset, filter)
+    # @return         [CircleCi::Response] - Response object
+    def recent_builds_branch(branch, params = {})
+      CircleCi.request(conf, "#{base_path}/tree/#{branch}", params).get
     end
 
     ##


### PR DESCRIPTION
- [x] Tests added
- [x] All tests pass
- [x] Branch is up to date and mergeable
- [x] README and documentation updated

## Changes

- Allow params to be passed to `Project#recent_builds_branch`
- Update README with example

## Verify

- Use params to filter or paginate recent builds for a project branch.

---

fixes #13