### PR TITLE
feat: Add ruby 2.6rc to build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,11 @@ version: 2
   working_directory: ~/app
 
 jobs:
-  build:
+  build_ruby2_6rc:
+    <<: *build_definition
+    docker:
+      - image: ruby:2.6-rc
+  build_ruby2_5:
     <<: *build_definition
     docker:
       - image: ruby:2.5
@@ -26,6 +30,7 @@ workflows:
   version: 2
   build_ruby_versions:
     jobs:
-      - build
+      - build_ruby2_6rc
+      - build_ruby2_5
       - build_ruby2_4
       - build_ruby2_3


### PR DESCRIPTION
- [x] Tests added
- [x] All tests pass
- [x] Branch is up to date and mergeable
- [x] README and documentation updated

## What

Check RC version of ruby in CI

## Changes

- Add ruby 2.6-rc to CI build jobs

## Verify

Check CI runs ruby 2.6-rc