### PR TITLE
Do not send a body for a GET request

### DIFF
--- a/lib/circleci/request.rb
+++ b/lib/circleci/request.rb
@@ -49,7 +49,7 @@ module CircleCi
 
     def connection(verb, body = {})
       req = Net::HTTP.const_get(verb.to_s.capitalize, false).new(@uri, DEFAULT_HEADERS)
-      req.body = JSON.dump(body)
+      req.body = JSON.dump(body) unless verb == :get
       req
     end
 


### PR DESCRIPTION
CircleCI doesn't like it

- ❌  Tests added (not needed)
- ✅  All tests pass
- ✅ Branch is up to date and mergeable
- ❌  README and documentation updated (not needed)

## Changes

Do not send data with GET requests. CircleCI has begun intermittently to fail, if a data is sent (even if that data is `"{}"`)

## Verify

    CircleCi::Project.new(org, project).recent_builds

CircleCI has started to return 403 Forbidden if this is sent with data.

You can also see the same effect in these curl requests. The first may fail, the second will not.

    curl -X GET --data-binary "{}" "https://circleci.com/api/v1.1/project/github/org/project?circle-token=TOKEN"
    curl -X GET "https://circleci.com/api/v1.1/project/github/org/project?circle-token=TOKEN"

---

